### PR TITLE
run new tests for qa deployments

### DIFF
--- a/.github/workflows/qa-deploy.yaml
+++ b/.github/workflows/qa-deploy.yaml
@@ -136,9 +136,6 @@ jobs:
           initial_status: success
           ref: ${{ github.event.pull_request.head.ref }}
 
-      # Allow time to spin up before running tests
-      - run: sleep 7m
-        if: ${{ github.repository == 'TeleVet/clinic-web' || github.repository == 'TeleVet/care-web' || github.repository == 'TeleVet/core-api' }}
 
       - name: Run Clinic Web Automation Tests
         uses: peter-evans/repository-dispatch@v1
@@ -146,7 +143,7 @@ jobs:
         with:
           token: ${{ secrets.e2e_repo_access_token }}
           repository: TeleVet/e2e-tests
-          event-type: clinic-web-automated-test
+          event-type: clinic-web-automated-test-isolated
           client-payload: '{"ref": "${{ github.event.pull_request.head.ref }}", "sha": "${{ github.event.pull_request.head.sha }}", "repository": "clinic-web", "user": "${{ github.actor }}", "qa_lane": "${{ steps.select-qa-env.outputs.env_name }}"}'
 
       - name: Run Care Web Automation Tests
@@ -155,7 +152,7 @@ jobs:
         with:
           token: ${{ secrets.e2e_repo_access_token }}
           repository: TeleVet/e2e-tests
-          event-type: care-web-automated-test
+          event-type: care-web-automated-test-isolated
           client-payload: '{"ref": "${{ github.event.pull_request.head.ref }}", "sha": "${{ github.event.pull_request.head.sha }}", "repository": "care-web", "user": "${{ github.actor }}", "qa_lane": "${{ steps.select-qa-env.outputs.env_name }}"}'
 
       - name: Run Core Api Automation Tests
@@ -164,5 +161,5 @@ jobs:
         with:
           token: ${{ secrets.e2e_repo_access_token }}
           repository: TeleVet/e2e-tests
-          event-type: core-api-automated-test
+          event-type: core-api-automated-test-isolated
           client-payload: '{"ref": "${{ github.event.pull_request.head.ref }}", "sha": "${{ github.event.pull_request.head.sha }}", "repository": "core-api", "user": "${{ github.actor }}", "qa_lane": "${{ steps.select-qa-env.outputs.env_name }}"}'


### PR DESCRIPTION
Remove sleep time and start running new isolated playwright tests for care and clinic-web deployments.