### PR TITLE
revert-isolated-tests

### DIFF
--- a/.github/workflows/qa-deploy.yaml
+++ b/.github/workflows/qa-deploy.yaml
@@ -136,11 +136,9 @@ jobs:
           initial_status: success
           ref: ${{ github.event.pull_request.head.ref }}
 
-
       # Allow time to spin up before running tests
       - run: sleep 7m
         if: ${{ github.repository == 'TeleVet/clinic-web' || github.repository == 'TeleVet/care-web'}}
-
 
       - name: Run Clinic Web Automation Tests
         uses: peter-evans/repository-dispatch@v1

--- a/.github/workflows/qa-deploy.yaml
+++ b/.github/workflows/qa-deploy.yaml
@@ -137,13 +137,18 @@ jobs:
           ref: ${{ github.event.pull_request.head.ref }}
 
 
+      # Allow time to spin up before running tests
+      - run: sleep 7m
+        if: ${{ github.repository == 'TeleVet/clinic-web' || github.repository == 'TeleVet/care-web'}}
+
+
       - name: Run Clinic Web Automation Tests
         uses: peter-evans/repository-dispatch@v1
         if: ${{ github.repository == 'TeleVet/clinic-web' }}
         with:
           token: ${{ secrets.e2e_repo_access_token }}
           repository: TeleVet/e2e-tests
-          event-type: clinic-web-automated-test-isolated
+          event-type: clinic-web-automated-test
           client-payload: '{"ref": "${{ github.event.pull_request.head.ref }}", "sha": "${{ github.event.pull_request.head.sha }}", "repository": "clinic-web", "user": "${{ github.actor }}", "qa_lane": "${{ steps.select-qa-env.outputs.env_name }}"}'
 
       - name: Run Care Web Automation Tests
@@ -152,7 +157,7 @@ jobs:
         with:
           token: ${{ secrets.e2e_repo_access_token }}
           repository: TeleVet/e2e-tests
-          event-type: care-web-automated-test-isolated
+          event-type: care-web-automated-test
           client-payload: '{"ref": "${{ github.event.pull_request.head.ref }}", "sha": "${{ github.event.pull_request.head.sha }}", "repository": "care-web", "user": "${{ github.actor }}", "qa_lane": "${{ steps.select-qa-env.outputs.env_name }}"}'
 
       - name: Run Core Api Automation Tests


### PR DESCRIPTION
move clinic-web and care-web back to old style tests

leave core-api repo dispatches pointed to isolated tests to keep troubleshooting.