### PR TITLE
add tests all to dispatch client-payload

### DIFF
--- a/.github/workflows/qa-deploy.yaml
+++ b/.github/workflows/qa-deploy.yaml
@@ -143,7 +143,7 @@ jobs:
           token: ${{ secrets.e2e_repo_access_token }}
           repository: TeleVet/e2e-tests
           event-type: clinic-web-automated-test-isolated
-          client-payload: '{"ref": "${{ github.event.pull_request.head.ref }}", "sha": "${{ github.event.pull_request.head.sha }}", "repository": "clinic-web", "user": "${{ github.actor }}", "qa_lane": "${{ steps.select-qa-env.outputs.env_name }}"}'
+          client-payload: '{"ref": "${{ github.event.pull_request.head.ref }}", "sha": "${{ github.event.pull_request.head.sha }}", "repository": "clinic-web", "user": "${{ github.actor }}", "qa_lane": "${{ steps.select-qa-env.outputs.env_name }}", "tests": "all"}'
 
       - name: Run Care Web Automation Tests
         uses: peter-evans/repository-dispatch@v1
@@ -152,7 +152,7 @@ jobs:
           token: ${{ secrets.e2e_repo_access_token }}
           repository: TeleVet/e2e-tests
           event-type: care-web-automated-test-isolated
-          client-payload: '{"ref": "${{ github.event.pull_request.head.ref }}", "sha": "${{ github.event.pull_request.head.sha }}", "repository": "care-web", "user": "${{ github.actor }}", "qa_lane": "${{ steps.select-qa-env.outputs.env_name }}"}'
+          client-payload: '{"ref": "${{ github.event.pull_request.head.ref }}", "sha": "${{ github.event.pull_request.head.sha }}", "repository": "care-web", "user": "${{ github.actor }}", "qa_lane": "${{ steps.select-qa-env.outputs.env_name }}", "tests": "all"}'
 
       - name: Run Core Api Automation Tests
         uses: peter-evans/repository-dispatch@v1
@@ -161,7 +161,7 @@ jobs:
           token: ${{ secrets.e2e_repo_access_token }}
           repository: TeleVet/e2e-tests
           event-type: core-api-automated-test-isolated
-          client-payload: '{"ref": "${{ github.event.pull_request.head.ref }}", "sha": "${{ github.event.pull_request.head.sha }}", "repository": "core-api", "user": "${{ github.actor }}", "qa_lane": "${{ steps.select-qa-env.outputs.env_name }}"}'
+          client-payload: '{"ref": "${{ github.event.pull_request.head.ref }}", "sha": "${{ github.event.pull_request.head.sha }}", "repository": "core-api", "user": "${{ github.actor }}", "qa_lane": "${{ steps.select-qa-env.outputs.env_name }}", "tests": "all"}'
 
       - name: Run Core Jobs Automation Tests
         uses: peter-evans/repository-dispatch@v1
@@ -170,7 +170,7 @@ jobs:
           token: ${{ secrets.e2e_repo_access_token }}
           repository: TeleVet/e2e-tests
           event-type: core-jobs-automated-test-isolated
-          client-payload: '{"ref": "${{ github.event.pull_request.head.ref }}", "sha": "${{ github.event.pull_request.head.sha }}", "repository": "core-jobs", "user": "${{ github.actor }}", "qa_lane": "${{ steps.select-qa-env.outputs.env_name }}"}'
+          client-payload: '{"ref": "${{ github.event.pull_request.head.ref }}", "sha": "${{ github.event.pull_request.head.sha }}", "repository": "core-jobs", "user": "${{ github.actor }}", "qa_lane": "${{ steps.select-qa-env.outputs.env_name }}", "tests": "all"}'
 
       - name: Run Payments Api Automation Tests
         uses: peter-evans/repository-dispatch@v1
@@ -179,7 +179,7 @@ jobs:
           token: ${{ secrets.e2e_repo_access_token }}
           repository: TeleVet/e2e-tests
           event-type: payments-api-automated-test-isolated
-          client-payload: '{"ref": "${{ github.event.pull_request.head.ref }}", "sha": "${{ github.event.pull_request.head.sha }}", "repository": "payments-api", "user": "${{ github.actor }}", "qa_lane": "${{ steps.select-qa-env.outputs.env_name }}"}'
+          client-payload: '{"ref": "${{ github.event.pull_request.head.ref }}", "sha": "${{ github.event.pull_request.head.sha }}", "repository": "payments-api", "user": "${{ github.actor }}", "qa_lane": "${{ steps.select-qa-env.outputs.env_name }}", "tests": "all"}'
 
       - name: Run Seach API Automation Tests
         uses: peter-evans/repository-dispatch@v1
@@ -188,5 +188,5 @@ jobs:
           token: ${{ secrets.e2e_repo_access_token }}
           repository: TeleVet/e2e-tests
           event-type: search-api-automated-test-isolated
-          client-payload: '{"ref": "${{ github.even.pull_request.head.ref }}", "sha": "${{ github.event.pull_request.head.sha }}", "repository": "search-api", "user": "${{ github.actor }}", "qa_lane": "${{ steps.select-qa-env.outputs.env_name }}"}'
+          client-payload: '{"ref": "${{ github.even.pull_request.head.ref }}", "sha": "${{ github.event.pull_request.head.sha }}", "repository": "search-api", "user": "${{ github.actor }}", "qa_lane": "${{ steps.select-qa-env.outputs.env_name }}", "tests": "all"}'
       


### PR DESCRIPTION
Add "tests": "all" to the client-payload for e2e-test dispatches. This way we are actually setting the value instead of leaving it blank and running everything anyway. 