### PR TITLE
Separate Workflow for Release Tags

### DIFF
--- a/.github/workflows/docker-build.yaml
+++ b/.github/workflows/docker-build.yaml
@@ -170,13 +170,12 @@ jobs:
           echo "${{ steps.meta.outputs.tags }}" > tags.txt
           image=$(cat tags.txt)
 
-          echo $image
-
           echo "==> Tagging image with additional tags!!!"
           for i in $image; do
             image_tag=$(echo "$i" | cut -d ":" -f 2)
+            echo ${image_tag}
 
-            IMAGE_META="$( aws ecr describe-images --repository-name=${{ inputs.image_name }} --image-ids=imageTag=$image_tag 2> /dev/null )"
+            IMAGE_META="$( aws ecr describe-images --repository-name=${{ inputs.image_name }} --image-ids=imageTag=${image_tag} || (echo "Command Failed" && exit 1) )"
 
             if [[ $? != 0 ]]; then
               aws ecr put-image --repository-name ${{ inputs.image_name }} --image-tag "$image_tag" --image-manifest "$IMAGE_MANIFEST"

--- a/.github/workflows/docker-build.yaml
+++ b/.github/workflows/docker-build.yaml
@@ -176,6 +176,14 @@ jobs:
           for i in $image; do
             image_tag=$(echo "$i" | cut -d ":" -f 2)
 
-            aws ecr put-image --repository-name ${{ inputs.image_name }} --image-tag "$image_tag" --image-manifest "$IMAGE_MANIFEST"
+            IMAGE_META="$( aws ecr describe-images --repository-name=${{ inputs.image_name }} --image-ids=imageTag=$image_tag 2> /dev/null )"
+
+            if [[ $? != 0 ]]; then
+              aws ecr put-image --repository-name ${{ inputs.image_name }} --image-tag "$image_tag" --image-manifest "$IMAGE_MANIFEST"
+            else
+              echo "Image with tag $image_tag already exists. Skipping."
+            fi
           done
           echo "DONE!!!"
+
+

--- a/.github/workflows/docker-build.yaml
+++ b/.github/workflows/docker-build.yaml
@@ -31,8 +31,6 @@ on:
           type=ref,event=branch,suffix=-${{ github.run_number }}
           type=sha,format=long
           type=sha,suffix=-${{ github.run_number }}
-          type=ref,event=tag
-          type=ref,event=tag,suffix=-${{ github.run_number }}
     secrets:
       build_args:
         description: Same as the `build-args` input on the [Docker Build and Push](https://github.com/docker/build-push-action#build-args-input) action.

--- a/.github/workflows/docker-build.yaml
+++ b/.github/workflows/docker-build.yaml
@@ -170,6 +170,8 @@ jobs:
           echo "${{ steps.meta.outputs.tags }}" > tags.txt
           image=$(cat tags.txt)
 
+          echo $image
+
           echo "==> Tagging image with additional tags!!!"
           for i in $image; do
             image_tag=$(echo "$i" | cut -d ":" -f 2)

--- a/.github/workflows/docker-build.yaml
+++ b/.github/workflows/docker-build.yaml
@@ -173,11 +173,10 @@ jobs:
           echo "==> Tagging image with additional tags!!!"
           for i in $image; do
             image_tag=$(echo "$i" | cut -d ":" -f 2)
-            echo ${image_tag}
 
-            IMAGE_META="$( aws ecr describe-images --repository-name=$1 --image-ids=imageTag=$2 ||: )"
+            IMAGE_META="$( aws ecr batch-get-image --repository-name=${{ inputs.image_name }} --image-ids=imageTag=$image_tag --query 'images[].imageId.imageTag' --output text )"
 
-            if [[ $? != 0 ]]; then
+            if [[ $IMAGE_META != $image_tag ]]; then
               aws ecr put-image --repository-name ${{ inputs.image_name }} --image-tag "$image_tag" --image-manifest "$IMAGE_MANIFEST"
             else
               echo "Image with tag $image_tag already exists. Skipping."

--- a/.github/workflows/docker-build.yaml
+++ b/.github/workflows/docker-build.yaml
@@ -175,7 +175,7 @@ jobs:
             image_tag=$(echo "$i" | cut -d ":" -f 2)
             echo ${image_tag}
 
-            IMAGE_META="$( aws ecr describe-images --repository-name=${{ inputs.image_name }} --image-ids=imageTag=${image_tag} || (echo "Command Failed" && exit 1) )"
+            IMAGE_META="$( aws ecr describe-images --repository-name=$1 --image-ids=imageTag=$2 ||: )"
 
             if [[ $? != 0 ]]; then
               aws ecr put-image --repository-name ${{ inputs.image_name }} --image-tag "$image_tag" --image-manifest "$IMAGE_MANIFEST"

--- a/.github/workflows/release-tags.yaml
+++ b/.github/workflows/release-tags.yaml
@@ -58,7 +58,7 @@ jobs:
 
       - name: Check and Tag Image with Commit SHA
         run: |
-          COMMIT_SHA=$(git rev-parse ${{ github.ref }})
+          COMMIT_SHA="sha-$(git rev-parse ${{ github.ref }})"
           IMAGE_META="$(aws ecr describe-images --repository-name=${{ inputs.image_name }} --image-ids=imageTag=$COMMIT_SHA 2> /dev/null)"
 
           if [[ $? == 0 ]]; then
@@ -70,4 +70,5 @@ jobs:
             aws ecr put-image --repository-name ${{ inputs.image_name }} --image-tag "$RELEASE_TAG" --image-manifest "$IMAGE_MANIFEST"
           else
             echo "Image with commit SHA $COMMIT_SHA not found."
+            exit 1
           fi

--- a/.github/workflows/release-tags.yaml
+++ b/.github/workflows/release-tags.yaml
@@ -55,20 +55,34 @@ jobs:
       - name: Login to Amazon ECR
         id: login-ecr
         uses: aws-actions/amazon-ecr-login@v1
+      
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v3
+        with:
+          images: ${{ inputs.registry }}/${{ inputs.image_name }}
+          tags: ${{ inputs.image_tags }}
 
-      - name: Check and Tag Image with Commit SHA
+      - name: Tag Image with Release Tag
         run: |
           COMMIT_SHA="sha-$(git rev-parse ${{ github.ref }})"
-          IMAGE_META="$(aws ecr describe-images --repository-name=${{ inputs.image_name }} --image-ids=imageTag=$COMMIT_SHA 2> /dev/null)"
+          IMAGE_META="$( aws ecr batch-get-image --repository-name=${{ inputs.image_name }} --image-ids=imageTag=$COMMIT_SHA --query 'images[].imageId.imageTag' --output text )"
+          
+          echo "${{ steps.meta.outputs.tags }}" > tags.txt
+          image=$(cat tags.txt)
 
-          if [[ $? == 0 ]]; then
+
+          if [[ $COMMIT_SHA == $IMAGE_META ]]; then
             echo "Image with commit SHA $COMMIT_SHA found."
+            export IMAGE_MANIFEST=$(aws ecr batch-get-image --repository-name ${{ inputs.image_name }} --image-ids imageTag=${COMMIT_SHA}-multi-arch --query 'images[].imageManifest' --output text | jq -r)
 
-            IMAGE_MANIFEST=$(aws ecr batch-get-image --repository-name ${{ inputs.image_name }} --image-ids imageTag=$COMMIT_SHA --query 'images[].imageManifest' --output text)
-
-            RELEASE_TAG=${{ github.ref_name }}
-            aws ecr put-image --repository-name ${{ inputs.image_name }} --image-tag "$RELEASE_TAG" --image-manifest "$IMAGE_MANIFEST"
+            for i in $image; do
+              image_tag=$(echo "$i" | cut -d ":" -f 2)
+              aws ecr put-image --repository-name ${{ inputs.image_name }} --image-tag "$image_tag" --image-manifest "$IMAGE_MANIFEST"
+              echo "Added Tag $image_tag to $IMAGE_META!!!"
+            done
           else
             echo "Image with commit SHA $COMMIT_SHA not found."
             exit 1
           fi
+

--- a/.github/workflows/release-tags.yaml
+++ b/.github/workflows/release-tags.yaml
@@ -55,25 +55,19 @@ jobs:
       - name: Login to Amazon ECR
         id: login-ecr
         uses: aws-actions/amazon-ecr-login@v1
-      
-      - name: Check Image with Commit SHA
-        id: check-image
+
+      - name: Check and Tag Image with Commit SHA
         run: |
           COMMIT_SHA=$(git rev-parse ${{ github.ref }})
           IMAGE_META="$(aws ecr describe-images --repository-name=${{ inputs.image_name }} --image-ids=imageTag=$COMMIT_SHA 2> /dev/null)"
 
           if [[ $? == 0 ]]; then
             echo "Image with commit SHA $COMMIT_SHA found."
-            echo "IMAGE_FOUND=true" >> $GITHUB_ENV
+
+            IMAGE_MANIFEST=$(aws ecr batch-get-image --repository-name ${{ inputs.image_name }} --image-ids imageTag=$COMMIT_SHA --query 'images[].imageManifest' --output text)
+
+            RELEASE_TAG=${{ github.ref_name }}
+            aws ecr put-image --repository-name ${{ inputs.image_name }} --image-tag "$RELEASE_TAG" --image-manifest "$IMAGE_MANIFEST"
           else
             echo "Image with commit SHA $COMMIT_SHA not found."
-            echo "IMAGE_FOUND=false" >> $GITHUB_ENV
           fi
-
-      - name: Tag Image with Release Tag
-        if: env.IMAGE_FOUND == 'true'
-        run: |
-          IMAGE_MANIFEST=$(aws ecr batch-get-image --repository-name ${{ inputs.image_name }} --image-ids imageTag=$COMMIT_SHA --query 'images[].imageManifest' --output text)
-
-          RELEASE_TAG=${{ github.ref_name }}  # Assuming the ref_name is the tag name
-          aws ecr put-image --repository-name ${{ inputs.image_name }} --image-tag "$RELEASE_TAG" --image-manifest "$IMAGE_MANIFEST"

--- a/.github/workflows/release-tags.yaml
+++ b/.github/workflows/release-tags.yaml
@@ -1,0 +1,79 @@
+name: Docker Tag Releases
+
+on:
+  workflow_call:
+    inputs:
+      role-to-assume:
+        type: string
+        description: ARN of the role to assume
+        required: true
+      role-session-name:
+        type: string
+        description: Name to use for role session
+        required: true
+      region:
+        type: string
+        description: AWS region to use
+        required: true
+      registry:
+        type: string
+        description: Registry for image
+        required: true
+      image_name:
+        type: string
+        description: Name for image
+        required: true
+      image_tags:
+        type: string
+        required: false
+        default: |
+          type=ref,event=tag
+          type=ref,event=tag,suffix=-${{ github.run_number }}
+
+env:
+  APP_NAME: ${{ inputs.app_name }}
+  IMAGE_REPO: ${{ inputs.registry }}/${{ inputs.image_name }}
+  IMAGE_TAG: ${{ inputs.image_tag }}
+
+jobs:
+  release-tag:
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+        
+      - name: Authenticate AWS Tools
+        uses: televet/actions-workflows/.github/actions/aws-auth@main
+        with:
+          role-session-name: ${{ inputs.role-session-name }}
+          role-to-assume: ${{ inputs.role-to-assume }}
+          region: ${{ inputs.region }}
+
+      - name: Login to Amazon ECR
+        id: login-ecr
+        uses: aws-actions/amazon-ecr-login@v1
+      
+      - name: Check Image with Commit SHA
+        id: check-image
+        run: |
+          COMMIT_SHA=$(git rev-parse ${{ github.ref }})
+          IMAGE_META="$(aws ecr describe-images --repository-name=${{ inputs.image_name }} --image-ids=imageTag=$COMMIT_SHA 2> /dev/null)"
+
+          if [[ $? == 0 ]]; then
+            echo "Image with commit SHA $COMMIT_SHA found."
+            echo "IMAGE_FOUND=true" >> $GITHUB_ENV
+          else
+            echo "Image with commit SHA $COMMIT_SHA not found."
+            echo "IMAGE_FOUND=false" >> $GITHUB_ENV
+          fi
+
+      - name: Tag Image with Release Tag
+        if: env.IMAGE_FOUND == 'true'
+        run: |
+          IMAGE_MANIFEST=$(aws ecr batch-get-image --repository-name ${{ inputs.image_name }} --image-ids imageTag=$COMMIT_SHA --query 'images[].imageManifest' --output text)
+
+          RELEASE_TAG=${{ github.ref_name }}  # Assuming the ref_name is the tag name
+          aws ecr put-image --repository-name ${{ inputs.image_name }} --image-tag "$RELEASE_TAG" --image-manifest "$IMAGE_MANIFEST"


### PR DESCRIPTION
We are currently getting the error below when we are trying to create a new-release tag:
[https://github.com/TeleVet/pawblisher/actions/runs/6240655444](https://github.com/TeleVet/pawblisher/actions/runs/6240655444)

To fix it, we will have a separate workflow for tagging images with the release tag. 