### PR TITLE
simplify check-action and repo-dispatch for tests

### DIFF
--- a/.github/workflows/qa-deploy.yaml
+++ b/.github/workflows/qa-deploy.yaml
@@ -146,7 +146,7 @@ jobs:
           initial_status: success
           ref: ${{ github.event.pull_request.head.ref }}
       
-      - name: Create Clinic Web Commit Check
+      - name: Create Playwright Commit Check
         id: check-id
         if: | 
           ${{ github.repository == 'TeleVet/clinic-web' ||

--- a/.github/workflows/qa-deploy.yaml
+++ b/.github/workflows/qa-deploy.yaml
@@ -148,7 +148,13 @@ jobs:
       
       - name: Create Clinic Web Commit Check
         id: check-id
-        if: ${{ github.repository == 'TeleVet/clinic-web' }}
+        if: | 
+          ${{ github.repository == 'TeleVet/clinic-web' ||
+          github.repository == 'TeleVet/care-web' ||
+          github.repository == 'TeleVet/core-api' || 
+          github.repository == 'TeleVet/core-jobs' ||
+          github.repository == 'TeleVet/payments-api' ||
+          github.repository == 'TeleVet/search-api' }}
         uses: LouisBrunner/checks-action@v1.6.2
         with:
           token: ${{ github.token }}
@@ -156,56 +162,18 @@ jobs:
           status: in_progress
           sha: ${{ github.event.pull_request.head.sha }}
 
-      - name: Run Clinic Web Automation Tests
+      - name: Run Playwright Automated Tests
         uses: peter-evans/repository-dispatch@v1
-        if: ${{ github.repository == 'TeleVet/clinic-web' }}
+        if: | 
+          ${{ github.repository == 'TeleVet/clinic-web' ||
+          github.repository == 'TeleVet/care-web' ||
+          github.repository == 'TeleVet/core-api' || 
+          github.repository == 'TeleVet/core-jobs' ||
+          github.repository == 'TeleVet/payments-api' ||
+          github.repository == 'TeleVet/search-api' }}
         with:
           token: ${{ secrets.e2e_repo_access_token }}
           repository: TeleVet/e2e-tests
-          event-type: clinic-web-automated-test-isolated
-          client-payload: '{"ref": "${{ github.event.pull_request.head.ref }}", "sha": "${{ github.event.pull_request.head.sha }}", "repository": "clinic-web", "user": "${{ github.actor }}", "qa_lane": "${{ steps.select-qa-env.outputs.env_name }}", "tests": "all", "check_id": "${{ steps.check-id.outputs.check_id }}"}'
+          event-type: playwright-automated-tests
+          client-payload: '{"ref": "${{ github.event.pull_request.head.ref }}", "sha": "${{ github.event.pull_request.head.sha }}", "repository": "${{ github.repository }}", "user": "${{ github.actor }}", "qa_lane": "${{ steps.select-qa-env.outputs.env_name }}", "tests": "all", "check_id": "${{ steps.check-id.outputs.check_id }}"}'
 
-      - name: Run Care Web Automation Tests
-        uses: peter-evans/repository-dispatch@v1
-        if: ${{ github.repository == 'TeleVet/care-web' }}
-        with:
-          token: ${{ secrets.e2e_repo_access_token }}
-          repository: TeleVet/e2e-tests
-          event-type: care-web-automated-test-isolated
-          client-payload: '{"ref": "${{ github.event.pull_request.head.ref }}", "sha": "${{ github.event.pull_request.head.sha }}", "repository": "care-web", "user": "${{ github.actor }}", "qa_lane": "${{ steps.select-qa-env.outputs.env_name }}", "tests": "all"}'
-
-      - name: Run Core Api Automation Tests
-        uses: peter-evans/repository-dispatch@v1
-        if: ${{ github.repository == 'TeleVet/core-api' }}
-        with:
-          token: ${{ secrets.e2e_repo_access_token }}
-          repository: TeleVet/e2e-tests
-          event-type: core-api-automated-test-isolated
-          client-payload: '{"ref": "${{ github.event.pull_request.head.ref }}", "sha": "${{ github.event.pull_request.head.sha }}", "repository": "core-api", "user": "${{ github.actor }}", "qa_lane": "${{ steps.select-qa-env.outputs.env_name }}", "tests": "all"}'
-
-      - name: Run Core Jobs Automation Tests
-        uses: peter-evans/repository-dispatch@v1
-        if: ${{ github.repository == 'TeleVet/core-jobs'  }}
-        with:
-          token: ${{ secrets.e2e_repo_access_token }}
-          repository: TeleVet/e2e-tests
-          event-type: core-jobs-automated-test-isolated
-          client-payload: '{"ref": "${{ github.event.pull_request.head.ref }}", "sha": "${{ github.event.pull_request.head.sha }}", "repository": "core-jobs", "user": "${{ github.actor }}", "qa_lane": "${{ steps.select-qa-env.outputs.env_name }}", "tests": "all"}'
-
-      - name: Run Payments Api Automation Tests
-        uses: peter-evans/repository-dispatch@v1
-        if: ${{ github.repository == 'TeleVet/payments-api' && inputs.app_name == 'payments-jobs' }}
-        with:
-          token: ${{ secrets.e2e_repo_access_token }}
-          repository: TeleVet/e2e-tests
-          event-type: payments-api-automated-test-isolated
-          client-payload: '{"ref": "${{ github.event.pull_request.head.ref }}", "sha": "${{ github.event.pull_request.head.sha }}", "repository": "payments-api", "user": "${{ github.actor }}", "qa_lane": "${{ steps.select-qa-env.outputs.env_name }}", "tests": "all"}'
-
-      - name: Run Seach API Automation Tests
-        uses: peter-evans/repository-dispatch@v1
-        if: ${{ github.repository == 'TeleVet/search-api'}}
-        with:
-          token: ${{ secrets.e2e_repo_access_token }}
-          repository: TeleVet/e2e-tests
-          event-type: search-api-automated-test-isolated
-          client-payload: '{"ref": "${{ github.even.pull_request.head.ref }}", "sha": "${{ github.event.pull_request.head.sha }}", "repository": "search-api", "user": "${{ github.actor }}", "qa_lane": "${{ steps.select-qa-env.outputs.env_name }}", "tests": "all"}'


### PR DESCRIPTION
Simplifying our steps into just two, where we are running them if the repository is one that we want to trigger playwright tests for. Dependency of https://github.com/TeleVet/e2e-tests/pull/213

**NOTE:** This turns on playwright commit checks for all branches we run playwright tests against.